### PR TITLE
Collection Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 config.json
+venv

--- a/internal/migration/migrate_data.go
+++ b/internal/migration/migrate_data.go
@@ -2,6 +2,8 @@ package migration
 
 import (
 	"log"
+
+	"github.com/TanmoySG/wdb-migrate/pkg/gen"
 )
 
 const wdbRetroIdKey = "_id"
@@ -17,8 +19,23 @@ func (mc MigrationClient) MigrateData(source SourceSink, sink SourceSink) {
 
 	res, err := mc.Clients.RetroClient.GetData(source.Database, source.Collection)
 	if err != nil {
-		log.Fatalf("Source Error: %s", err.Error())
+		log.Fatalf("Source Error: %s", err)
 	}
+
+	// TODO: Check if Collection exists only thnen create it
+	// mc.Clients.WdbClient.GetCollection(sink.Database, sink.Collection)
+
+	generatedJsonSchema, err := gen.GenerateJsonSchema(res.Data)
+	if err != nil {
+		log.Fatalf("Schema Generation Error: %s", err)
+	}
+
+	err = mc.Clients.WdbClient.CreateCollection(sink.Database, sink.Collection, generatedJsonSchema)
+	if err != nil {
+		log.Fatalf("Sink Error: %s, Collection not created", err)
+	}
+
+	// externalize the GenSchema and CreateCollection along with TODO to separate func
 
 	for r, rb := range res.Data {
 		cleanedData := rb
@@ -27,7 +44,7 @@ func (mc MigrationClient) MigrateData(source SourceSink, sink SourceSink) {
 		md := mc.Clients.WdbClient.Use(sink.Database, sink.Collection)
 		err := md.AddData(rb)
 		if err != nil {
-			log.Println(err.Error())
+			log.Println(err)
 			continue
 		}
 

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -1,0 +1,69 @@
+package gen
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const wdbRetroIdKey = "_id"
+const jsonSchemaRequiredFieldKey = "required"
+
+func sampleData(data map[string]interface{}) ([]byte, error) {
+	samplerData := map[string]interface{}{}
+
+	for _, rb := range data {
+		// picks first element from map
+		samplerData = rb.(map[string]interface{})
+		break
+	}
+
+	if len(samplerData) == 0 {
+		return nil, fmt.Errorf("no data found for sampling")
+	}
+
+	delete(samplerData, wdbRetroIdKey)
+
+	samplerDataBytes, err := json.Marshal(samplerData)
+	if err != nil {
+		return nil, err
+	}
+
+	return samplerDataBytes, nil
+}
+
+func GenerateJsonSchema(data map[string]interface{}) (map[string]interface{}, error) {
+	sampledData, err := sampleData(data)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("echo", string(sampledData))
+	catOutput, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	gensonCmd := exec.Command("genson")
+	gensonCmd.Stdin = strings.NewReader(string(catOutput))
+
+	generatedJSONSchemaBytes, err := gensonCmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var generatedJSONSchema map[string]interface{}
+
+	err = json.Unmarshal(generatedJSONSchemaBytes, &generatedJSONSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	// for safe migration remove `required` field for json schema
+	// migrated schema should be flexible as incoming data is from v0
+	// and might be incompatible
+	delete(generatedJSONSchema, jsonSchemaRequiredFieldKey)
+
+	return generatedJSONSchema, nil
+}


### PR DESCRIPTION
Closes #3 

Collection Migration from wdb-retro v0 to wdb v1 instances, followed by Data Migration (https://github.com/TanmoySG/wdb-migrate/issues/1)

Pre-requisites

- Create database with same/different name
- Since the Schema in wdb v0 is not JSON Schema, so we need to format the schema from sample data in collection
- Use some online API to generate JSON Schema from JSON Sample (Tool: genson )
- Using the generated JSON Schema, create a collection in wdb v1 w/ same name